### PR TITLE
Updated post-build commands to work around bugs in MonoDevelop

### DIFF
--- a/Misc/TestPlugins/InvalidPlugin/InvalidPlugin.csproj
+++ b/Misc/TestPlugins/InvalidPlugin/InvalidPlugin.csproj
@@ -46,8 +46,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(TargetPath)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(TargetPath)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(ProjectDir)bin\$(ConfigurationName)\$(TargetName)$(TargetExt)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(ProjectDir)bin/$(ConfigurationName)/$(TargetName)$(TargetExt)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Misc/TestPlugins/ValidPlugin1/ValidPlugin1.csproj
+++ b/Misc/TestPlugins/ValidPlugin1/ValidPlugin1.csproj
@@ -55,8 +55,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(TargetPath)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(TargetPath)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(ProjectDir)bin\$(ConfigurationName)\$(TargetName)$(TargetExt)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(ProjectDir)bin/$(ConfigurationName)/$(TargetName)$(TargetExt)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Misc/TestPlugins/ValidPlugin2/ValidPlugin2.csproj
+++ b/Misc/TestPlugins/ValidPlugin2/ValidPlugin2.csproj
@@ -55,8 +55,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(TargetPath)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(TargetPath)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(ProjectDir)bin\$(ConfigurationName)\$(TargetName)$(TargetExt)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(ProjectDir)bin/$(ConfigurationName)/$(TargetName)$(TargetExt)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Misc/TestPlugins/ValidPlugin3/ValidPlugin3.csproj
+++ b/Misc/TestPlugins/ValidPlugin3/ValidPlugin3.csproj
@@ -55,8 +55,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(TargetPath)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(TargetPath)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /y "$(ProjectDir)bin\$(ConfigurationName)\$(TargetName)$(TargetExt)" "$(ProjectDir)..\..\..\Binaries\$(ConfigurationName)\TestPlugins\"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mkdir -p "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/" &amp;&amp; cp "$(ProjectDir)bin/$(ConfigurationName)/$(TargetName)$(TargetExt)" "$(ProjectDir)../../../Binaries/$(ConfigurationName)/TestPlugins/"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
MonoDevelop incorrectly implements $(TargetPath) variable in post-build events. Updated the command with a workaround. Tested in Xamarin Studio (win), Visual Studio (win) and MonoDevelop (linux).
