### PR TITLE
Made tests more independent from the development config files

### DIFF
--- a/Misc/WebTests/AvatarTests.cs
+++ b/Misc/WebTests/AvatarTests.cs
@@ -19,6 +19,9 @@ namespace WebTests
         public void StartServer()
         {
             server = new FIVESServerInstance();
+            server.ConfigureClientManagerPorts(34837);
+            server.ConfigurePluginsAndProtocols(new string[] { "Auth", "Avatar", "ClientManager", "KIARA", "Location",
+                "Motion", "Testing", "Renderable", "EventLoop", "Editing" }, new string[] { "WebSocketJSON" });
             server.Start();
         }
 
@@ -34,7 +37,8 @@ namespace WebTests
             IWebDriver driver = Tools.CreateDriver();
             try
             {
-                driver.Navigate().GoToUrl("http://localhost/projects/test-client/client.xhtml");
+                driver.Navigate().GoToUrl(
+                    "http://localhost/projects/test-client/client.xhtml#FIVESTesting&OverrideServerPort=34837");
                 Tools.Login(driver, "1", "");
 
                 WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
@@ -67,8 +71,10 @@ namespace WebTests
 
             try
             {
-                driver1.Navigate().GoToUrl("http://localhost/projects/test-client/client.xhtml");
-                driver2.Navigate().GoToUrl("http://localhost/projects/test-client/client.xhtml");
+                driver1.Navigate().GoToUrl(
+                    "http://localhost/projects/test-client/client.xhtml#FIVESTesting&OverrideServerPort=34837");
+                driver2.Navigate().GoToUrl(
+                    "http://localhost/projects/test-client/client.xhtml#FIVESTesting&OverrideServerPort=34837");
 
                 Tools.Login(driver1, "1", "");
                 Tools.Login(driver2, "2", "");

--- a/Misc/WebTests/LoginTests.cs
+++ b/Misc/WebTests/LoginTests.cs
@@ -17,6 +17,9 @@ namespace WebTests
         public void StartServer()
         {
             server = new FIVESServerInstance();
+            server.ConfigureClientManagerPorts(34837);
+            server.ConfigurePluginsAndProtocols(new string[] { "Auth", "Avatar", "ClientManager", "KIARA", "Location",
+                "Motion", "Testing", "Renderable", "EventLoop", "Editing" }, new string[] { "WebSocketJSON" });
             server.Start();
         }
 
@@ -30,6 +33,8 @@ namespace WebTests
         public void StartChrome()
         {
             driver = Tools.CreateDriver();
+            driver.Navigate().GoToUrl(
+                "http://localhost/projects/test-client/client.xhtml#FIVESTesting&OverrideServerPort=34837");
         }
 
         [TearDown]

--- a/Misc/WebTests/ServerSyncTests.cs
+++ b/Misc/WebTests/ServerSyncTests.cs
@@ -17,13 +17,19 @@ namespace WebTests
         public void StartServer()
         {
             server1 = new FIVESServerInstance();
-            ConfigureServerSyncPorts(server1, 43745, new int[] {});
-            ConfigureClientManagerPorts(server1, 34837);
+            server1.ConfigureServerSyncPorts(43745, new int[] {});
+            server1.ConfigureClientManagerPorts(34837);
+            server1.ConfigurePluginsAndProtocols(new string[] { "Auth", "Avatar", "ClientManager", "KIARA", "Location",
+                "Motion", "Testing", "Renderable", "EventLoop", "Editing", "ServerSync", "ConfigScalability",
+                "Scalability" }, new string[] { "WebSocketJSON" });
             server1.Start();
 
             server2 = new FIVESServerInstance();
-            ConfigureServerSyncPorts(server2, 43746, new int[] { 43745 });
-            ConfigureClientManagerPorts(server2, 34839);
+            server2.ConfigureServerSyncPorts(43746, new int[] { 43745 });
+            server2.ConfigureClientManagerPorts(34839);
+            server2.ConfigurePluginsAndProtocols(new string[] { "Auth", "Avatar", "ClientManager", "KIARA", "Location",
+                "Motion", "Testing", "Renderable", "EventLoop", "Editing", "ServerSync", "ConfigScalability",
+                "Scalability" }, new string[] { "WebSocketJSON" });
             server2.Start();
         }
 
@@ -79,33 +85,6 @@ namespace WebTests
                 driver1.Quit();
                 driver2.Quit();
             }
-        }
-
-        private void ConfigureServerSyncPorts(FIVESServerInstance server, int listeningPort, int[] remotePorts)
-        {
-            string serverConfigPath = Path.Combine(server.TestDirectory, "serverSyncServer.json");
-            string serverConfig = File.ReadAllText(serverConfigPath);
-            serverConfig = serverConfig.Replace("43745", listeningPort.ToString());
-            File.WriteAllText(serverConfigPath, serverConfig);
-
-            string clientConfigPath = Path.Combine(server.TestDirectory, "serverSyncClient.json");
-            StringBuilder clientConfig = new StringBuilder();
-            clientConfig.Append("{'info':'ScalabilitySyncClient','idlURL':'syncServer.kiara','servers':[");
-            foreach (int remotePort in remotePorts)
-            {
-                clientConfig.Append("{'services':'*','protocol':{'name':'websocket-json','port':" + remotePort +
-                    ",'host':'127.0.0.1'}},");
-            }
-            clientConfig.Append("]}");
-            File.WriteAllText(clientConfigPath, clientConfig.ToString());
-        }
-
-        private void ConfigureClientManagerPorts(FIVESServerInstance server, int listeningPort)
-        {
-            string clientManagerConfigPath = Path.Combine(server.TestDirectory, "clientManagerServer.json");
-            string clientManagerConfig = File.ReadAllText(clientManagerConfigPath);
-            clientManagerConfig = clientManagerConfig.Replace("34837", listeningPort.ToString());
-            File.WriteAllText(clientManagerConfigPath, clientManagerConfig);
         }
     }
 }

--- a/Misc/WebTests/Tools.cs
+++ b/Misc/WebTests/Tools.cs
@@ -36,7 +36,6 @@ namespace WebTests
             ChromeOptions options = new ChromeOptions();
             options.AddArgument("--disable-cache");
             var driver = new ChromeDriver(options);
-            driver.Navigate().GoToUrl("http://localhost/projects/test-client/client.xhtml");
             return driver;
         }
     }


### PR DESCRIPTION
In particular list of plugins, protocols, ClientManager and ServerSync configs can be now specified in the test for each created server instance. This was partially available before in the ServerSync tests, but was moved into ServerSyncInstance class to make it available for all WebTests.
