### PR TITLE
Client animation speed adaption

### DIFF
--- a/WebClient/scripts/plugins/animation/animation.js
+++ b/WebClient/scripts/plugins/animation/animation.js
@@ -84,9 +84,8 @@ requirejs(["keyframe_animator"], (function () {
         for (var i in registeredEntities) {
             var entity = registeredEntities[i];
             if(entity)
-                this._keyframeAnimator.increaseAnimationKeys(entity, 1000.0 / deltaTime);
+                this._keyframeAnimator.increaseAnimationKeys(entity, deltaTime);
         }
-
         var self = this;
         requestAnimationFrame(updateLoop.bind(self));
     };

--- a/WebClient/scripts/plugins/animation/keyframe_animator.js
+++ b/WebClient/scripts/plugins/animation/keyframe_animator.js
@@ -34,7 +34,7 @@ FIVES.Plugins.Animation = FIVES.Plugins.Animation || {};
         }
     };
 
-    a.increaseAnimationKeys = function(entity, fps) {
+    a.increaseAnimationKeys = function(entity, frameDuration) {
         var playingAnimations = entity.playingAnimationsCollection;
         if(playingAnimations)
         {
@@ -44,14 +44,17 @@ FIVES.Plugins.Animation = FIVES.Plugins.Animation || {};
                 var xflowKey = entity.xml3dView.xflowAnimations[animationName].key;
 
                 var oldValue = parseFloat(xflowKey.text());
-                var newValue = this._computeNewKeyframeValue(playingAnimation, oldValue, fps);
+                var newValue = this._computeNewKeyframeValue(playingAnimation, oldValue, frameDuration);
                 xflowKey.text(newValue);
             }
         }
     };
 
-    a._computeNewKeyframeValue = function(playingAnimation, oldValue, fps) {
-        var newValue = oldValue + playingAnimation.speed * fps / 1000.0;
+    a._computeNewKeyframeValue = function(playingAnimation, oldValue, frameDuration) {
+        // Animation speed is designed such that a speed of 1 means 1 second of animation per keyframe.
+        // We compute the new value based on last frame's duration so that we increase keys higher when the
+        // rendering the last frame took long
+        var newValue = oldValue + playingAnimation.speed * (frameDuration / 1000.0);
         if (newValue > playingAnimation.endFrame)
         {
             newValue = this._increaseAnimationCycles(playingAnimation, newValue);


### PR DESCRIPTION
Old computation of updated keyframes for client side animations used window.setTimeout with fixed value for keyframe updates. This approach is not encouraged, one should rather use requestAnimationFrame instead.

Fixes employ this method and moreover correct computation of key frames w.r.t frame rendering time, resulting in smooth animations independent of frame rate
